### PR TITLE
Update Schema creation for ES>2

### DIFF
--- a/js/src/streammachine/analytics/es_templates.js
+++ b/js/src/streammachine/analytics/es_templates.js
@@ -78,7 +78,7 @@ module.exports = {
           ips: {
             type: "string",
             index: "not_analyzed",
-            index_name: "ip",
+            copy_to: "ip",
             doc_values: true
           }
         })


### PR DESCRIPTION
Update Schema creation to be compatible with ES > 2, index_name was deprecated and give error.
Reference: https://github.com/elastic/elasticsearch/issues/11079
